### PR TITLE
fixed // capture indent, reorganized keywords

### DIFF
--- a/grammars/jack.cson
+++ b/grammars/jack.cson
@@ -4,19 +4,15 @@
 'name': 'Jack'
 'patterns': [
   {
-    'match': '\\b(class|int|char|boolean|void)\\b'
-    'name': 'storage.type.jack'
-  }
-  {
-    'match': '\\b(constructor|function|method)\\b'
+    'match': '\\b(int|char|boolean|void)\\b'
     'name': 'storage.modifier.jack'
   }
   {
-    'match': '\\b(field|static|var)\\b'
-    'name': 'storage.modifier.jack'
+    'match': '\\b(constructor|function|method|class)\\b'
+    'name': 'keyword.control.jack'
   }
   {
-    'match': '\\b(let|if|else|while|do|return)\\b'
+    'match': '\\b(let|if|else|while|do|return|var|field|static)\\b'
     'name': 'keyword.control.jack'
   }
   {
@@ -61,8 +57,8 @@
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.comment.jack'
-      'end': '\\n'
-      'name': 'comment.line.double-slash.jack'
+    'end': '\\n'
+    'name': 'comment.line.double-slash.jack'
   }
 ]
 'scopeName': 'source.jack'


### PR DESCRIPTION
Hi! I and my classmates had a big problem where the highlighting would stop after the first // comment. I found out that (or at least this solved it) two lines were indented incorrectly in the cson file. (The last two diffs in the file.

I also didn't like how keywords were grouped together. With this new grouping there is identical highlighting for any keyword that can begin a statement. (var should look the same as do and let, IMO.)

If you don't like the new grouping, though, the indentation should at least be fixed. Thanks!
